### PR TITLE
fix: Parse author ID when it is a GID-formatted ID

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch GitLab Webhook Server",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/main.go",
+      "args": ["gitlab", "server"],
+      "envFile": "${workspaceFolder}/.env"
+    },
+    {
+      "name": "Evaulate",
+      "type": "go",
+      "request": "launch",
+      "mode": "debug",
+      "program": "${workspaceFolder}/main.go",
+      "args": ["gitlab", "evaluate"],
+      "envFile": "${workspaceFolder}/.env"
+    }
+  ]
+}

--- a/pkg/scm/gitlab/client_actioner_assign.go
+++ b/pkg/scm/gitlab/client_actioner_assign.go
@@ -3,6 +3,7 @@ package gitlab
 import (
 	"context"
 	"log/slog"
+	"strconv"
 
 	"github.com/jippi/scm-engine/pkg/scm"
 	"github.com/jippi/scm-engine/pkg/state"
@@ -57,8 +58,9 @@ func (c *Client) AssignReviewers(ctx context.Context, evalContext scm.EvalContex
 			return err
 		}
 
+		authorID := strconv.Itoa(evalContext.GetAuthor().IntID())
 		for _, owner := range owners {
-			if evalContext.GetAuthor().ID != owner.ID {
+			if authorID != owner.ID {
 				eligibleReviewers = append(eligibleReviewers, owner)
 			}
 		}


### PR DESCRIPTION
Author would get assign their own MR when the Author id was a GID, so it would not match the condition.