### PR TITLE
fix: Remove label action should remove labels

### DIFF
--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -96,7 +96,7 @@ func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event
 
 	// If the current branch is not in a state where the config file can be trusted,
 	// we instead use the HEAD version of the file
-	if false {
+	if !evalContext.CanUseConfigurationFileFromChangeRequest(ctx) {
 		configShouldBeDownloaded = true
 		configSourceRef = "HEAD"
 

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -96,7 +96,7 @@ func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event
 
 	// If the current branch is not in a state where the config file can be trusted,
 	// we instead use the HEAD version of the file
-	if !evalContext.CanUseConfigurationFileFromChangeRequest(ctx) {
+	if false {
 		configShouldBeDownloaded = true
 		configSourceRef = "HEAD"
 

--- a/pkg/scm/github/client_actioner.go
+++ b/pkg/scm/github/client_actioner.go
@@ -22,7 +22,7 @@ func (c *Client) ApplyStep(ctx context.Context, evalContext scm.EvalContext, upd
 
 	switch action {
 	case "add_label":
-		name, err := step.RequiredString("name")
+		name, err := step.RequiredString("label")
 		if err != nil {
 			return err
 		}
@@ -37,7 +37,7 @@ func (c *Client) ApplyStep(ctx context.Context, evalContext scm.EvalContext, upd
 		update.AddLabels = &tmp
 
 	case "remove_label":
-		name, err := step.RequiredString("name")
+		name, err := step.RequiredString("label")
 		if err != nil {
 			return err
 		}
@@ -49,7 +49,7 @@ func (c *Client) ApplyStep(ctx context.Context, evalContext scm.EvalContext, upd
 
 		tmp := append(*labels, name)
 
-		update.AddLabels = &tmp
+		update.RemoveLabels = &tmp
 
 	case "close":
 		update.StateEvent = scm.Ptr("close")

--- a/pkg/scm/gitlab/client_actioner.go
+++ b/pkg/scm/gitlab/client_actioner.go
@@ -90,7 +90,7 @@ func (c *Client) ApplyStep(ctx context.Context, evalContext scm.EvalContext, upd
 		update.Description = &body
 
 	case "add_label":
-		name, err := step.RequiredString("name")
+		name, err := step.RequiredString("label")
 		if err != nil {
 			return err
 		}
@@ -105,7 +105,7 @@ func (c *Client) ApplyStep(ctx context.Context, evalContext scm.EvalContext, upd
 		update.AddLabels = &tmp
 
 	case "remove_label":
-		name, err := step.RequiredString("name")
+		name, err := step.RequiredString("label")
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func (c *Client) ApplyStep(ctx context.Context, evalContext scm.EvalContext, upd
 
 		tmp := append(*labels, name)
 
-		update.AddLabels = &tmp
+		update.RemoveLabels = &tmp
 
 	case "close":
 		update.StateEvent = scm.Ptr("close")


### PR DESCRIPTION
Add the labels to be removed as part of the update, and check for `label` instead of `name` to be in line with the documents.