### PR TITLE
feat: Global configuration file

### DIFF
--- a/cmd/conventions.go
+++ b/cmd/conventions.go
@@ -9,6 +9,7 @@ const (
 	FlagCommitSHA                                       = "commit"
 	FlagConfigFile                                      = "config"
 	FlagDryRun                                          = "dry-run"
+	FlagGlobalConfigFile                                = "global-config"
 	FlagMergeRequestID                                  = "id"
 	FlagSCMBaseURL                                      = "base-url"
 	FlagSCMProject                                      = "project"

--- a/cmd/gitlab.go
+++ b/cmd/gitlab.go
@@ -14,6 +14,7 @@ var GitLab = &cli.Command{
 		cCtx.Context = state.WithBaseURL(cCtx.Context, cCtx.String(FlagSCMBaseURL))
 		cCtx.Context = state.WithProvider(cCtx.Context, "gitlab")
 		cCtx.Context = state.WithToken(cCtx.Context, cCtx.String(FlagAPIToken))
+		cCtx.Context = state.WithGlobalConfigFilePath(cCtx.Context, cCtx.String(FlagGlobalConfigFile))
 
 		return nil
 	},
@@ -32,6 +33,14 @@ var GitLab = &cli.Command{
 			EnvVars: []string{
 				"SCM_ENGINE_BASE_URL", // SCM Engine Native
 				"CI_SERVER_URL",       // GitLab CI
+			},
+		},
+		&cli.StringFlag{
+			Name:  FlagGlobalConfigFile,
+			Usage: "Path to a global configuration file. Any repository specific configuration will be merged on top of the global configuration",
+			Value: "",
+			EnvVars: []string{
+				"SCM_ENGINE_GLOBAL_CONFIG_FILE",
 			},
 		},
 	},

--- a/cmd/gitlab_evaluate.go
+++ b/cmd/gitlab_evaluate.go
@@ -16,10 +16,23 @@ func Evaluate(cCtx *cli.Context) error {
 	ctx = state.WithProjectID(ctx, cCtx.String(FlagSCMProject))
 	ctx = state.WithToken(ctx, cCtx.String(FlagAPIToken))
 	ctx = state.WithUpdatePipeline(ctx, cCtx.Bool(FlagUpdatePipeline), cCtx.String(FlagUpdatePipelineURL))
+	ctx = state.WithGlobalConfigFilePath(ctx, cCtx.String(FlagGlobalConfigFile))
 
 	// Optional Backstage catalog integration
 	ctx = state.WithBackstageURL(ctx, cCtx.String(FlagBackstageURL))
 	ctx = state.WithBackstageToken(ctx, cCtx.String(FlagBackstageToken))
+
+	//
+	// Setup global config if present
+	//
+	if state.GlobalConfigFilePath(ctx) != "" {
+		globalCfg, err := config.LoadFile(state.GlobalConfigFilePath(ctx))
+		if err != nil {
+			return err
+		}
+
+		ctx = config.WithConfig(ctx, globalCfg)
+	}
 
 	cfg, err := config.LoadFile(state.ConfigFilePath(ctx))
 	if err != nil {

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -148,8 +148,8 @@ func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event
 		return fmt.Errorf("Configuration failed validation: %w", err)
 	}
 
-	// Write the config to context so we can pull it out later, if a global config file was set
-	// this overrides the global config with the merge global and repository config
+	// Write the config to context so we can pull it out later
+	// If a global config file was set, this overrides the global config with the merged global and repository config
 	ctx = config.WithConfig(ctx, cfg)
 
 	//

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -123,7 +123,8 @@ func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event
 	// Merge previously loaded config with Repository config
 	ctxConfig := config.FromContext(ctx) // the global config if previously loaded
 	if ctxConfig != nil && cfg != nil {
-		cfg = ctxConfig.Merge(cfg)
+		ctxConfig.Merge(cfg)
+		cfg = ctxConfig
 	}
 
 	// Sanity check for having a configuration loaded

--- a/cmd/shared.go
+++ b/cmd/shared.go
@@ -120,6 +120,12 @@ func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event
 		}
 	}
 
+	// Merge previously loaded config with Repository config
+	ctxConfig := config.FromContext(ctx) // the global config if previously loaded
+	if ctxConfig != nil && cfg != nil {
+		cfg = ctxConfig.Merge(cfg)
+	}
+
 	// Sanity check for having a configuration loaded
 	if cfg == nil {
 		return errors.New("cfg==nil; this is unexpected an error, please report!")
@@ -142,7 +148,8 @@ func ProcessMR(ctx context.Context, client scm.Client, cfg *config.Config, event
 		return fmt.Errorf("Configuration failed validation: %w", err)
 	}
 
-	// Write the config to context so we can pull it out later
+	// Write the config to context so we can pull it out later, if a global config file was set
+	// this overrides the global config with the merge global and repository config
 	ctx = config.WithConfig(ctx, cfg)
 
 	//

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -4,6 +4,10 @@ The default configuration filename is `.scm-engine.yml`, either in current worki
 
 The file path can be changed via `--config` CLI flag and `#!css $SCM_ENGINE_CONFIG_FILE` environment variable.
 
+A global configuration file can be specified via the `--global-config` CLI flag and `#!css $SCM_ENGINE_GLOBAL_CONFIG_FILE` environment variable.
+
+The global configuration file is optional, and if specified, the default configuration will be merged on top of the global configuration.
+
 ## `ignore_activity_from` {#ignore_activity_from data-toc-label="ignore_activity_from"}
 
 !!! question "What is 'activity'?"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ The file path can be changed via `--config` CLI flag and `#!css $SCM_ENGINE_CONF
 
 A global configuration file can be specified via the `--global-config` CLI flag and `#!css $SCM_ENGINE_GLOBAL_CONFIG_FILE` environment variable.
 
-The global configuration file is optional, and if specified, the default configuration will be merged on top of the global configuration.
+The global configuration file is optional, and if specified, the repository's configuration will be merged on top of the global configuration.
 
 ## `ignore_activity_from` {#ignore_activity_from data-toc-label="ignore_activity_from"}
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -6,7 +6,7 @@ The file path can be changed via `--config` CLI flag and `#!css $SCM_ENGINE_CONF
 
 A global configuration file can be specified via the `--global-config` CLI flag and `#!css $SCM_ENGINE_GLOBAL_CONFIG_FILE` environment variable.
 
-The global configuration file is optional, and if specified, the repository's configuration will be merged on top of the global configuration.
+The global configuration file is optional, and if specified, the repository's configuration will be merged on top of the global configuration. This means that includes, actions, and labels in the repository configuration will be appended to what is set in the global configuration.
 
 ## `ignore_activity_from` {#ignore_activity_from data-toc-label="ignore_activity_from"}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/jippi/scm-engine/pkg/scm"
@@ -152,20 +151,4 @@ func (c *Config) Merge(other *Config) *Config {
 	c.Includes = append(c.Includes, other.Includes...)
 
 	return c
-}
-
-func key(project string, ref *string, file string) string {
-	var builder strings.Builder
-
-	builder.WriteString(project)
-
-	if ref != nil {
-		builder.WriteString(":")
-		builder.WriteString(*ref)
-	}
-
-	builder.WriteString(":")
-	builder.WriteString(file)
-
-	return builder.String()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -155,16 +155,16 @@ func (c *Config) Merge(other *Config) *Config {
 }
 
 func key(project string, ref *string, file string) string {
-	var b strings.Builder
-	b.WriteString(project)
+	var builder strings.Builder
+	builder.WriteString(project)
 
 	if ref != nil {
-		b.WriteString(":")
-		b.WriteString(*ref)
+		builder.WriteString(":")
+		builder.WriteString(*ref)
 	}
 
-	b.WriteString(":")
-	b.WriteString(file)
+	builder.WriteString(":")
+	builder.WriteString(file)
 
-	return b.String()
+	return builder.String()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/hashicorp/go-multierror"
 	"github.com/jippi/scm-engine/pkg/scm"
@@ -147,5 +148,23 @@ func (c *Config) Merge(other *Config) *Config {
 	c.Actions = append(c.Actions, other.Actions...)
 	c.Labels = append(c.Labels, other.Labels...)
 
+	// don't have to worry about duplication here, it is handled when loading the includes
+	c.Includes = append(c.Includes, other.Includes...)
+
 	return c
+}
+
+func key(project string, ref *string, file string) string {
+	var b strings.Builder
+	b.WriteString(project)
+
+	if ref != nil {
+		b.WriteString(":")
+		b.WriteString(*ref)
+	}
+
+	b.WriteString(":")
+	b.WriteString(file)
+
+	return b.String()
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -129,3 +129,23 @@ func (c *Config) LoadIncludes(ctx context.Context, client scm.Client) error {
 
 	return nil
 }
+
+// Merge merges the other config into the current config
+func (c *Config) Merge(other *Config) *Config {
+	if other == nil {
+		return c
+	}
+
+	if other.DryRun != nil {
+		c.DryRun = other.DryRun
+	}
+
+	c.IgnoreActivityFrom.IsBot = other.IgnoreActivityFrom.IsBot
+	c.IgnoreActivityFrom.Usernames = append(c.IgnoreActivityFrom.Usernames, other.IgnoreActivityFrom.Usernames...)
+	c.IgnoreActivityFrom.Emails = append(c.IgnoreActivityFrom.Emails, other.IgnoreActivityFrom.Emails...)
+
+	c.Actions = append(c.Actions, other.Actions...)
+	c.Labels = append(c.Labels, other.Labels...)
+
+	return c
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -131,14 +131,12 @@ func (c *Config) LoadIncludes(ctx context.Context, client scm.Client) error {
 }
 
 // Merge merges the other config into the current config
-func (c *Config) Merge(other *Config) *Config {
+func (c *Config) Merge(other *Config) {
 	if other == nil {
-		return c
+		return
 	}
 
-	if other.DryRun != nil {
-		c.DryRun = other.DryRun
-	}
+	c.DryRun = other.DryRun
 
 	c.IgnoreActivityFrom.IsBot = other.IgnoreActivityFrom.IsBot
 	c.IgnoreActivityFrom.Usernames = append(c.IgnoreActivityFrom.Usernames, other.IgnoreActivityFrom.Usernames...)
@@ -150,5 +148,5 @@ func (c *Config) Merge(other *Config) *Config {
 	// don't have to worry about duplication here, it is handled when loading the includes
 	c.Includes = append(c.Includes, other.Includes...)
 
-	return c
+	return
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -156,6 +156,7 @@ func (c *Config) Merge(other *Config) *Config {
 
 func key(project string, ref *string, file string) string {
 	var builder strings.Builder
+
 	builder.WriteString(project)
 
 	if ref != nil {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -81,6 +81,19 @@ func TestConfig_Merge(t *testing.T) {
 			},
 			want: &config.Config{Labels: config.Labels{{Name: "label1"}, {Name: "label2"}}},
 		},
+		{
+			name: "merge includes",
+			cfg:  &config.Config{Includes: []config.Include{{Project: "project1", Ref: scm.Ptr("ref1"), Files: []string{"file1"}}}},
+			other: &config.Config{
+				Includes: []config.Include{{Project: "project1", Ref: scm.Ptr("ref1"), Files: []string{"file2"}}},
+			},
+			want: &config.Config{
+				Includes: []config.Include{
+					{Project: "project1", Ref: scm.Ptr("ref1"), Files: []string{"file1"}},
+					{Project: "project1", Ref: scm.Ptr("ref1"), Files: []string{"file2"}},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -28,7 +28,7 @@ func TestConfig_Merge(t *testing.T) {
 			},
 		},
 		{
-			name: "do not override dry run when other dry run is nil",
+			name: "override dry run",
 			cfg: &config.Config{
 				DryRun: scm.Ptr(false),
 			},
@@ -36,7 +36,7 @@ func TestConfig_Merge(t *testing.T) {
 				DryRun: nil,
 			},
 			want: &config.Config{
-				DryRun: scm.Ptr(false),
+				DryRun: nil,
 			},
 		},
 		{

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,94 @@
+package config_test
+
+import (
+	"testing"
+
+	"github.com/jippi/scm-engine/pkg/config"
+	"github.com/jippi/scm-engine/pkg/scm"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfig_Merge(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		cfg   *config.Config
+		other *config.Config
+		want  *config.Config
+	}{
+		{
+			name: "merge when other is nil",
+			cfg: &config.Config{
+				DryRun: scm.Ptr(false),
+			},
+			other: nil,
+			want: &config.Config{
+				DryRun: scm.Ptr(false),
+			},
+		},
+		{
+			name: "do not override dry run when other dry run is nil",
+			cfg: &config.Config{
+				DryRun: scm.Ptr(false),
+			},
+			other: &config.Config{
+				DryRun: nil,
+			},
+			want: &config.Config{
+				DryRun: scm.Ptr(false),
+			},
+		},
+		{
+			name: "merge ignore activity",
+			cfg: &config.Config{
+				IgnoreActivityFrom: config.IgnoreActivityFrom{
+					IsBot:     false,
+					Usernames: []string{"user1"},
+					Emails:    []string{"user2@example.com"},
+				},
+			},
+			other: &config.Config{
+				IgnoreActivityFrom: config.IgnoreActivityFrom{
+					IsBot:     true,
+					Usernames: []string{"user3"},
+					Emails:    []string{"user4@example.com"},
+				},
+			},
+			want: &config.Config{
+				IgnoreActivityFrom: config.IgnoreActivityFrom{
+					IsBot:     true,
+					Usernames: []string{"user1", "user3"},
+					Emails:    []string{"user2@example.com", "user4@example.com"},
+				},
+			},
+		},
+		{
+			name: "merge actions",
+			cfg: &config.Config{
+				Actions: []config.Action{{Name: "action1"}},
+			},
+			other: &config.Config{
+				Actions: []config.Action{{Name: "action2"}},
+			},
+			want: &config.Config{Actions: []config.Action{{Name: "action1"}, {Name: "action2"}}},
+		},
+		{
+			name: "merge labels",
+			cfg:  &config.Config{Labels: config.Labels{{Name: "label1"}}},
+			other: &config.Config{
+				Labels: config.Labels{{Name: "label2"}},
+			},
+			want: &config.Config{Labels: config.Labels{{Name: "label1"}, {Name: "label2"}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tt.cfg.Merge(tt.other)
+			require.Equal(t, tt.want, tt.cfg)
+		})
+	}
+}

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -29,6 +29,7 @@ const (
 	randomSeed
 	backstageURL
 	backstageToken
+	globalConfigFilePath
 )
 
 func ProjectID(ctx context.Context) string {
@@ -194,6 +195,16 @@ func BackstageToken(ctx context.Context) string {
 
 func WithBackstageToken(ctx context.Context, value string) context.Context {
 	ctx = context.WithValue(ctx, backstageToken, value)
+
+	return ctx
+}
+
+func GlobalConfigFilePath(ctx context.Context) string {
+	return ctx.Value(globalConfigFilePath).(string) //nolint:forcetypeassert
+}
+
+func WithGlobalConfigFilePath(ctx context.Context, value string) context.Context {
+	ctx = context.WithValue(ctx, globalConfigFilePath, value)
 
 	return ctx
 }


### PR DESCRIPTION
This is for cases where global configuration is preferable over ensuring all repositories have an `.scm-engine.yml` present in the repository.

This follows the pattern where the most granular configuration, e.g. the repository configuration, gets merged on top of the global configuration.

Global configuration is opt-in, and must be set via the `SCM_ENGINE_GLOBAL_CONFIG_FILE`, the value being a path that is locally accessible.

The schema is the same as that of the default configuration file.