### PR TITLE
Fix GitLab commit order

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,3 +13,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.go]
+indent_style = tab
+indent_size = 4

--- a/pkg/scm/github/context.go
+++ b/pkg/scm/github/context.go
@@ -54,23 +54,23 @@ func NewContext(ctx context.Context, _, token string) (*Context, error) {
 	evalContext.PullRequest.Labels = evalContext.PullRequest.ResponseLabels.Nodes
 	evalContext.PullRequest.ResponseLabels = nil
 
-	if len(evalContext.PullRequest.ResponseFirstCommits.Nodes) > 0 {
-		evalContext.PullRequest.FirstCommit = evalContext.PullRequest.ResponseFirstCommits.Nodes[0].Commit
+	if len(evalContext.PullRequest.ResponseOldestCommits.Nodes) > 0 {
+		evalContext.PullRequest.FirstCommit = evalContext.PullRequest.ResponseOldestCommits.Nodes[0].Commit
 
 		tmp := time.Since(evalContext.PullRequest.FirstCommit.CommittedDate)
 		evalContext.PullRequest.TimeSinceFirstCommit = &tmp
 	}
 
-	evalContext.PullRequest.ResponseFirstCommits = nil
+	evalContext.PullRequest.ResponseOldestCommits = nil
 
-	if len(evalContext.PullRequest.ResponseLastCommits.Nodes) > 0 {
-		evalContext.PullRequest.LastCommit = evalContext.PullRequest.ResponseLastCommits.Nodes[0].Commit
+	if len(evalContext.PullRequest.ResponseNewestCommits.Nodes) > 0 {
+		evalContext.PullRequest.LastCommit = evalContext.PullRequest.ResponseNewestCommits.Nodes[0].Commit
 
 		tmp := time.Since(evalContext.PullRequest.LastCommit.CommittedDate)
 		evalContext.PullRequest.TimeSinceLastCommit = &tmp
 	}
 
-	evalContext.PullRequest.ResponseLastCommits = nil
+	evalContext.PullRequest.ResponseNewestCommits = nil
 
 	if evalContext.PullRequest.FirstCommit != nil && evalContext.PullRequest.LastCommit != nil {
 		tmp := evalContext.PullRequest.FirstCommit.CommittedDate.Sub(evalContext.PullRequest.LastCommit.CommittedDate).Round(time.Hour)

--- a/pkg/scm/gitlab/context.go
+++ b/pkg/scm/gitlab/context.go
@@ -70,23 +70,23 @@ func NewContext(ctx context.Context, baseURL, token string) (*Context, error) {
 	evalContext.MergeRequest.Notes = evalContext.MergeRequest.ResponseNotes.Nodes
 	evalContext.MergeRequest.ResponseNotes.Nodes = nil
 
-	if len(evalContext.MergeRequest.ResponseFirstCommits.Nodes) > 0 {
-		evalContext.MergeRequest.FirstCommit = &evalContext.MergeRequest.ResponseFirstCommits.Nodes[0]
+	if len(evalContext.MergeRequest.ResponseOldestCommits.Nodes) > 0 {
+		evalContext.MergeRequest.FirstCommit = &evalContext.MergeRequest.ResponseOldestCommits.Nodes[0]
 
 		tmp := time.Since(*evalContext.MergeRequest.FirstCommit.CommittedDate)
 		evalContext.MergeRequest.TimeSinceFirstCommit = &tmp
 	}
 
-	evalContext.MergeRequest.ResponseFirstCommits = nil
+	evalContext.MergeRequest.ResponseOldestCommits = nil
 
-	if len(evalContext.MergeRequest.ResponseLastCommits.Nodes) > 0 {
-		evalContext.MergeRequest.LastCommit = &evalContext.MergeRequest.ResponseLastCommits.Nodes[0]
+	if len(evalContext.MergeRequest.ResponseNewestCommits.Nodes) > 0 {
+		evalContext.MergeRequest.LastCommit = &evalContext.MergeRequest.ResponseNewestCommits.Nodes[0]
 
 		tmp := time.Since(*evalContext.MergeRequest.LastCommit.CommittedDate)
 		evalContext.MergeRequest.TimeSinceLastCommit = &tmp
 	}
 
-	evalContext.MergeRequest.ResponseLastCommits = nil
+	evalContext.MergeRequest.ResponseNewestCommits = nil
 
 	if evalContext.MergeRequest.FirstCommit != nil && evalContext.MergeRequest.LastCommit != nil {
 		tmp := evalContext.MergeRequest.FirstCommit.CommittedDate.Sub(*evalContext.MergeRequest.LastCommit.CommittedDate).Round(time.Hour)

--- a/schema/github.schema.graphqls
+++ b/schema/github.schema.graphqls
@@ -423,9 +423,9 @@ type ContextPullRequest {
     @graphql(key: "files(first:100)")
     @internal
 
-  "Information about the first commit made"
+  "Information about the first (oldest) commit made"
   FirstCommit: ContextCommit @generated
-  "Information about the last commit made"
+  "Information about the last (newest) commit made"
   LastCommit: ContextCommit @generated
   "Duration between first and last commit made"
   TimeBetweenFirstAndLastCommit: Duration @generated
@@ -436,10 +436,10 @@ type ContextPullRequest {
   "Labels available on this project"
   Labels: [ContextLabel!] @generated
 
-  ResponseFirstCommits: ContextCommitsNode
+  ResponseOldestCommits: ContextCommitsNode
     @internal
     @graphql(key: "first_commit: commits(first:1)")
-  ResponseLastCommits: ContextCommitsNode
+  ResponseNewestCommits: ContextCommitsNode
     @internal
     @graphql(key: "last_commit: commits(last:1)")
   ResponseLabels: ContextLabelConnection

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -381,9 +381,9 @@ type ContextMergeRequest {
   "All notes on this MR"
   Notes: [ContextNote!] @generated
 
-  "Information about the first commit made"
+  "Information about the first (oldest) commit made"
   FirstCommit: ContextCommit @generated
-  "Information about the last commit made"
+  "Information about the last (newest) commit made"
   LastCommit: ContextCommit @generated
   "Duration between first and last commit made"
   TimeBetweenFirstAndLastCommit: Duration @generated
@@ -400,10 +400,10 @@ type ContextMergeRequest {
   CurrentReviewers: ContextUsersNode @internal @graphql(key: "reviewers")
   CurrentUser: ContextUser! @generated @internal
   ResponseLabels: ContextLabelNode @internal @graphql(key: "labels(first: 200)")
-  ResponseFirstCommits: ContextCommitsNode
+  ResponseOldestCommits: ContextCommitsNode
     @internal
     @graphql(key: "first_commit: commits(first:1)")
-  ResponseLastCommits: ContextCommitsNode
+  ResponseNewestCommits: ContextCommitsNode
     @internal
     @graphql(key: "last_commit: commits(last:1)")
   ResponseNotes: ContextNotesNode @internal @graphql(key: "notes(last: 10)")

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -400,12 +400,15 @@ type ContextMergeRequest {
   CurrentReviewers: ContextUsersNode @internal @graphql(key: "reviewers")
   CurrentUser: ContextUser! @generated @internal
   ResponseLabels: ContextLabelNode @internal @graphql(key: "labels(first: 200)")
+  # Note: commits() seems to be in descending order, meaning that:
+  # - The "last:1" commit is the oldest one, which we refer to as the "first commit on the MR"
+  # - The "first:1" commit is the newest one, which we refer to as the "last commit on the MR"
   ResponseOldestCommits: ContextCommitsNode
     @internal
-    @graphql(key: "first_commit: commits(first:1)")
+    @graphql(key: "oldest_commit: commits(last:1)")
   ResponseNewestCommits: ContextCommitsNode
     @internal
-    @graphql(key: "last_commit: commits(last:1)")
+    @graphql(key: "newest_commit: commits(first:1)")
   ResponseNotes: ContextNotesNode @internal @graphql(key: "notes(last: 10)")
 }
 


### PR DESCRIPTION
scm-engine assumes that GitLab returns the commit list in ascending order (oldest to newest) but upon examining the results myself I'm seeing them listed in reverse (descending) order. This explains why scm-engine is incorrectly labelling some MRs as "stale" - it's looking at the oldest (not newest) commits!

This PR attempts to fix this by:

- Changing the naming convention within the GraphQL queries and corresponding logic to use "oldest" and "newest" as the internal property names
  - This allows us to modify whether the queries are looking at the "first" or "last" entries in the list without that knowledge leaking into our logic and causing confusion
- Fixing the GitLab queries to use the `first` (latest) commit as the "newest" and the `last` commit as the "oldest"