### PR TITLE
feat: Support pipeline events#273

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /scm-engine
 /scm-engine.exe
 scm-engine.schema.json
+.scm-engine.global.yml

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -79,9 +79,15 @@ tasks:
       - gofumpt -w -l .
 
   lint:
-    desc: Lint the code with golangci-lint
+    desc: Lint the code with golangci-lint (uses same version as CI)
     cmds:
       - golangci-lint run --config ./.golangci.yaml ./...
+
+  lint:install:
+    desc: Install golangci-lint v1.64.8 (same as CI)
+    cmds:
+      - go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8
+      - golangci-lint --version
 
   ci:
     desc: Run all CI steps

--- a/cmd/gitlab_server_handlers.go
+++ b/cmd/gitlab_server_handlers.go
@@ -113,9 +113,11 @@ func GitLabWebhookHandler(ctx context.Context, webhookSecret string) http.Handle
 		// Build context for rest of the pipeline
 		ctx = state.WithCommitSHA(ctx, gitSha)
 		ctx = state.WithMergeRequestID(ctx, id)
+
 		if pipelineID != "" {
 			ctx = state.WithPipelineID(ctx, pipelineID)
 		}
+
 		ctx = slogctx.With(ctx, slog.String("event_type", eventType))
 
 		slogctx.Info(ctx, "GET /gitlab webhook")

--- a/cmd/gitlab_server_handlers_test.go
+++ b/cmd/gitlab_server_handlers_test.go
@@ -1,0 +1,50 @@
+package cmd_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/jippi/scm-engine/cmd"
+	"github.com/jippi/scm-engine/pkg/state"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGitLabWebhookHandler_PipelinePayloadWithNilMergeRequest_Returns400(t *testing.T) {
+	t.Parallel()
+
+	// Pipeline payload with object_attributes set but merge_request omitted (nil).
+	// GitLab sends this for branch/tag pipelines that are not associated with an MR.
+	body := `{
+		"object_kind": "pipeline",
+		"project": {
+			"path_with_namespace": "group/my-project"
+		},
+		"object_attributes": {
+			"iid": 12345,
+			"commit": {"id": "abc123def"},
+			"last_commit": {}
+		}
+	}`
+
+	ctx := t.Context()
+	ctx = state.WithProvider(ctx, "gitlab")
+	ctx = state.WithToken(ctx, "fake-token")
+	ctx = state.WithBaseURL(ctx, "http://fake-gitlab.example")
+	ctx = state.WithBackstageURL(ctx, "")
+	ctx = state.WithBackstageToken(ctx, "")
+
+	handler := cmd.GitLabWebhookHandler(ctx, "")
+
+	req := httptest.NewRequest(http.MethodPost, "/gitlab", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	require.Equal(t, http.StatusBadRequest, rec.Code, "expected 400 when pipeline payload has no merge_request")
+	assert.Contains(t, rec.Body.String(), "not associated with a merge request",
+		"response body should explain that payload is not associated with a merge request")
+}

--- a/cmd/gitlab_server_helpers.go
+++ b/cmd/gitlab_server_helpers.go
@@ -22,3 +22,4 @@ func errHandler(ctx context.Context, w http.ResponseWriter, code int, err error)
 
 	return
 }
+

--- a/cmd/gitlab_server_helpers.go
+++ b/cmd/gitlab_server_helpers.go
@@ -19,7 +19,4 @@ func errHandler(ctx context.Context, w http.ResponseWriter, code int, err error)
 
 	w.WriteHeader(code)
 	w.Write([]byte(err.Error()))
-
-	return
 }
-

--- a/cmd/gitlab_server_structs.go
+++ b/cmd/gitlab_server_structs.go
@@ -2,6 +2,7 @@ package cmd
 
 type GitlabWebhookPayload struct {
 	EventType        string                                `json:"event_type"`
+	ObjectKind       string                                `json:"object_kind"`                 // "object_kind" is sent e.g. "pipeline" when event_type is omitted
 	Project          GitlabWebhookPayloadProject           `json:"project"`                     // "project" is sent for all events
 	ObjectAttributes *GitlabWebhookPayloadObjectAttributes `json:"object_attributes,omitempty"` // "object_attributes" is sent on "merge_request" events and "pipeline" events
 	MergeRequest     *GitlabWebhookPayloadMergeRequest     `json:"merge_request,omitempty"`     // "merge_request" is sent on "note" activity and "pipeline" events
@@ -18,7 +19,10 @@ type GitlabWebhookPayloadObjectAttributes struct {
 }
 
 func (o *GitlabWebhookPayloadObjectAttributes) GetCommitID() string {
-	if o.LastCommit != nil {
+	if o == nil {
+		return ""
+	}
+	if o.LastCommit.ID != "" {
 		return o.LastCommit.ID
 	}
 	return o.Commit.ID
@@ -27,6 +31,13 @@ func (o *GitlabWebhookPayloadObjectAttributes) GetCommitID() string {
 type GitlabWebhookPayloadMergeRequest struct {
 	IID        int                        `json:"iid"`
 	LastCommit GitlabWebhookPayloadCommit `json:"last_commit"`
+}
+
+func (m *GitlabWebhookPayloadMergeRequest) GetCommitID() string {
+	if m == nil {
+		return ""
+	}
+	return m.LastCommit.ID
 }
 
 type GitlabWebhookPayloadCommit struct {

--- a/cmd/gitlab_server_structs.go
+++ b/cmd/gitlab_server_structs.go
@@ -1,17 +1,29 @@
 package cmd
 
 type GitlabWebhookPayload struct {
-	EventType        string                            `json:"event_type"`
-	Project          GitlabWebhookPayloadProject       `json:"project"`                     // "project" is sent for all events
-	ObjectAttributes *GitlabWebhookPayloadMergeRequest `json:"object_attributes,omitempty"` // "object_attributes" is sent on "merge_request" events and "pipeline" events
-	MergeRequest     *GitlabWebhookPayloadMergeRequest `json:"merge_request,omitempty"`     // "merge_request" is sent on "note" activity and "pipeline" events
+	EventType        string                                `json:"event_type"`
+	Project          GitlabWebhookPayloadProject           `json:"project"`                     // "project" is sent for all events
+	ObjectAttributes *GitlabWebhookPayloadObjectAttributes `json:"object_attributes,omitempty"` // "object_attributes" is sent on "merge_request" events and "pipeline" events
+	MergeRequest     *GitlabWebhookPayloadMergeRequest     `json:"merge_request,omitempty"`     // "merge_request" is sent on "note" activity and "pipeline" events
 }
 
 type GitlabWebhookPayloadProject struct {
 	PathWithNamespace string `json:"path_with_namespace"`
 }
 
-// TODO: handle for https://docs.gitlab.com/user/project/integrations/webhook_events/#pipeline-events, since last_commit is not sent on pipeline events, only sha
+type GitlabWebhookPayloadObjectAttributes struct {
+	IID        int                        `json:"iid"`
+	LastCommit GitlabWebhookPayloadCommit `json:"last_commit"`
+	Commit     GitlabWebhookPayloadCommit `json:"commit"`
+}
+
+func (o *GitlabWebhookPayloadObjectAttributes) GetCommitID() string {
+	if o.LastCommit != nil {
+		return o.LastCommit.ID
+	}
+	return o.Commit.ID
+}
+
 type GitlabWebhookPayloadMergeRequest struct {
 	IID        int                        `json:"iid"`
 	LastCommit GitlabWebhookPayloadCommit `json:"last_commit"`

--- a/cmd/gitlab_server_structs.go
+++ b/cmd/gitlab_server_structs.go
@@ -22,9 +22,11 @@ func (o *GitlabWebhookPayloadObjectAttributes) GetCommitID() string {
 	if o == nil {
 		return ""
 	}
+
 	if o.LastCommit.ID != "" {
 		return o.LastCommit.ID
 	}
+
 	return o.Commit.ID
 }
 
@@ -37,6 +39,7 @@ func (m *GitlabWebhookPayloadMergeRequest) GetCommitID() string {
 	if m == nil {
 		return ""
 	}
+
 	return m.LastCommit.ID
 }
 

--- a/cmd/gitlab_server_structs.go
+++ b/cmd/gitlab_server_structs.go
@@ -1,5 +1,7 @@
 package cmd
 
+import "strconv"
+
 type GitlabWebhookPayload struct {
 	EventType        string                                `json:"event_type"`
 	ObjectKind       string                                `json:"object_kind"`                 // "object_kind" is sent e.g. "pipeline" when event_type is omitted
@@ -18,6 +20,14 @@ type GitlabWebhookPayloadObjectAttributes struct {
 	Commit     GitlabWebhookPayloadCommit `json:"commit"`
 }
 
+func (o *GitlabWebhookPayloadObjectAttributes) GetIID() string {
+	if o == nil {
+		return ""
+	}
+
+	return strconv.Itoa(o.IID)
+}
+
 func (o *GitlabWebhookPayloadObjectAttributes) GetCommitID() string {
 	if o == nil {
 		return ""
@@ -33,6 +43,14 @@ func (o *GitlabWebhookPayloadObjectAttributes) GetCommitID() string {
 type GitlabWebhookPayloadMergeRequest struct {
 	IID        int                        `json:"iid"`
 	LastCommit GitlabWebhookPayloadCommit `json:"last_commit"`
+}
+
+func (m *GitlabWebhookPayloadMergeRequest) GetIID() string {
+	if m == nil {
+		return ""
+	}
+
+	return strconv.Itoa(m.IID)
 }
 
 func (m *GitlabWebhookPayloadMergeRequest) GetCommitID() string {

--- a/cmd/gitlab_server_structs.go
+++ b/cmd/gitlab_server_structs.go
@@ -3,14 +3,15 @@ package cmd
 type GitlabWebhookPayload struct {
 	EventType        string                            `json:"event_type"`
 	Project          GitlabWebhookPayloadProject       `json:"project"`                     // "project" is sent for all events
-	ObjectAttributes *GitlabWebhookPayloadMergeRequest `json:"object_attributes,omitempty"` // "object_attributes" is sent on "merge_request" events
-	MergeRequest     *GitlabWebhookPayloadMergeRequest `json:"merge_request,omitempty"`     // "merge_request" is sent on "note" activity
+	ObjectAttributes *GitlabWebhookPayloadMergeRequest `json:"object_attributes,omitempty"` // "object_attributes" is sent on "merge_request" events and "pipeline" events
+	MergeRequest     *GitlabWebhookPayloadMergeRequest `json:"merge_request,omitempty"`     // "merge_request" is sent on "note" activity and "pipeline" events
 }
 
 type GitlabWebhookPayloadProject struct {
 	PathWithNamespace string `json:"path_with_namespace"`
 }
 
+// TODO: handle for https://docs.gitlab.com/user/project/integrations/webhook_events/#pipeline-events, since last_commit is not sent on pipeline events, only sha
 type GitlabWebhookPayloadMergeRequest struct {
 	IID        int                        `json:"iid"`
 	LastCommit GitlabWebhookPayloadCommit `json:"last_commit"`

--- a/docs/gitlab/examples.md
+++ b/docs/gitlab/examples.md
@@ -301,10 +301,10 @@ label:
 actions:
   - name: "notify-pipeline-failure"
     if: |
-      pipeline != nil
-      && pipeline.status == "FAILED"
-      && pipeline.source == "merge_request_event"
-      && pipeline.hasFailedJobs()
+      webhook_event != nil
+      && webhook_event.object_kind == "pipeline"
+      && pipeline != nil
+      && pipeline.has_failed_jobs()
     then:
       - action: comment
         message: |

--- a/docs/gitlab/examples.md
+++ b/docs/gitlab/examples.md
@@ -265,35 +265,9 @@ Pipeline events are triggered when a pipeline's status changes (created, running
     To use pipeline events, enable "Pipeline events" in your GitLab project's webhook settings.
     Pipeline events are only processed when they are associated with a merge request.
 
-### Add labels based on pipeline status
-
-```yaml
-# yaml-language-server: $schema=https://jippi.github.io/scm-engine/scm-engine.schema.json
-
-label:
-  - name: "ci/passed"
-    color: $green
-    script: |
-      pipeline != nil
-      && pipeline.status == "SUCCESS"
-      && pipeline.source == "merge_request_event"
-
-  - name: "ci/failed"
-    color: $red
-    script: |
-      pipeline != nil
-      && pipeline.status == "FAILED"
-      && pipeline.source == "merge_request_event"
-
-  - name: "ci/running"
-    color: $yellow
-    script: |
-      pipeline != nil
-      && pipeline.status == "RUNNING"
-      && pipeline.source == "merge_request_event"
-```
-
 ### Comment on failed pipeline with job details
+
+Use `pipeline.has_failed_jobs()` to detect when any job in the pipeline has failed, then comment on the merge request:
 
 ```yaml
 # yaml-language-server: $schema=https://jippi.github.io/scm-engine/scm-engine.schema.json
@@ -313,74 +287,13 @@ actions:
           The pipeline has failed. Please check the pipeline logs for more details.
 ```
 
-### Label slow pipelines
-
-```yaml
-# yaml-language-server: $schema=https://jippi.github.io/scm-engine/scm-engine.schema.json
-
-label:
-  - name: "ci/slow-pipeline"
-    color: $orange
-    description: "Pipeline took longer than 30 minutes"
-    script: |
-      pipeline != nil
-      && pipeline.status == "SUCCESS"
-      && pipeline.duration != nil
-      && pipeline.duration > 1800
-```
-
 ### Pipeline Context Reference
-
-When handling pipeline events, the following fields are available in the `pipeline` object:
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `pipeline.id` | string | Global ID of the pipeline |
-| `pipeline.iid` | string | Pipeline internal ID |
-| `pipeline.name` | string | Pipeline name |
-| `pipeline.ref` | string | Git ref (branch/tag) |
-| `pipeline.tag` | bool | Whether this is a tag pipeline |
-| `pipeline.sha` | string | Commit SHA |
-| `pipeline.source` | string | Pipeline source: `merge_request_event`, `push`, `web`, `api`, `trigger`, `schedule`, `pipeline` |
-| `pipeline.status` | string | Status: `CREATED`, `WAITING_FOR_RESOURCE`, `PREPARING`, `PENDING`, `RUNNING`, `SUCCESS`, `FAILED`, `CANCELED`, `SKIPPED`, `MANUAL`, `SCHEDULED` |
-| `pipeline.active` | bool | Whether the pipeline is active |
-| `pipeline.cancelable` | bool | Whether the pipeline can be canceled |
-| `pipeline.complete` | bool | Whether the pipeline is complete |
-| `pipeline.duration` | int | Duration in seconds (nil if not finished) |
-| `pipeline.failure_reason` | string | Reason for failure (if failed) |
-| `pipeline.finished_at` | time | Timestamp when pipeline finished |
-| `pipeline.latest` | bool | Whether this is the latest pipeline |
-| `pipeline.path` | string | Relative path to the pipeline's page |
-| `pipeline.retryable` | bool | Whether the pipeline can be retried |
-| `pipeline.started_at` | time | Timestamp when pipeline started |
-| `pipeline.stuck` | bool | Whether the pipeline is stuck |
-| `pipeline.total_jobs` | int | Total number of jobs in the pipeline |
-| `pipeline.updated_at` | time | Timestamp of last update |
-| `pipeline.warnings` | bool | Whether the pipeline has warnings |
-| `pipeline.jobs` | []Job | List of jobs in the pipeline |
-
-**Job fields:**
-
-| Field | Type | Description |
-|-------|------|-------------|
-| `job.id` | string | Job ID |
-| `job.name` | string | Job name |
-| `job.status` | string | Job status |
-| `job.stage.name` | string | Stage name |
-| `job.ref` | string | Git ref for the job |
-| `job.duration` | int | Duration in seconds |
-| `job.active` | bool | Whether the job is active |
-| `job.allow_failure` | bool | Whether allowed to fail |
-| `job.manual_job` | bool | Whether this is a manual job |
-| `job.retried` | bool | Whether the job was retried |
-| `job.scheduled_at` | time | Scheduled start time |
-| `job.stuck` | bool | Whether the job is stuck |
 
 **Helper methods:**
 
 | Method | Description |
 |--------|-------------|
-| `pipeline.hasFailedJobs()` | Returns true if any job has status "failed" |
+| `pipeline.has_failed_jobs()` | Returns true if any job has status "failed" |
 
 !!! tip "Pipeline is nil for non-pipeline events"
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/datolabs-io/go-backstage/v3 v3.0.0
 	github.com/davecgh/go-spew v1.1.1
-	github.com/expr-lang/expr v1.17.7
+	github.com/expr-lang/expr v1.17.8
 	github.com/fatih/structtag v1.2.0
 	github.com/golang-cz/devslog v0.0.11
 	github.com/google/go-github/v67 v67.0.0

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.0.0
 	github.com/datolabs-io/go-backstage/v3 v3.0.0
 	github.com/davecgh/go-spew v1.1.1
-	github.com/expr-lang/expr v1.17.0
+	github.com/expr-lang/expr v1.17.7
 	github.com/fatih/structtag v1.2.0
 	github.com/golang-cz/devslog v0.0.11
 	github.com/google/go-github/v67 v67.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/jippi/scm-engine
 
 go 1.24.0
 
-toolchain go1.24.11
+toolchain go1.24.13
 
 require (
 	github.com/99designs/gqlgen v0.17.84

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7c
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/expr-lang/expr v1.17.0 h1:+vpszOyzKLQXC9VF+wA8cVA0tlA984/Wabc/1hF9Whg=
-github.com/expr-lang/expr v1.17.0/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/expr-lang/expr v1.17.7 h1:Q0xY/e/2aCIp8g9s/LGvMDCC5PxYlvHgDZRQ4y16JX8=
+github.com/expr-lang/expr v1.17.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=

--- a/go.sum
+++ b/go.sum
@@ -31,8 +31,8 @@ github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54 h1:SG7nF6SRlWhcT7c
 github.com/dgryski/trifles v0.0.0-20230903005119-f50d829f2e54/go.mod h1:if7Fbed8SFyPtHLHbg49SI7NAdJiC5WIA09pe59rfAA=
 github.com/dlclark/regexp2 v1.11.0 h1:G/nrcoOa7ZXlpoa/91N3X7mM3r8eIlMBBJZvsz/mxKI=
 github.com/dlclark/regexp2 v1.11.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
-github.com/expr-lang/expr v1.17.7 h1:Q0xY/e/2aCIp8g9s/LGvMDCC5PxYlvHgDZRQ4y16JX8=
-github.com/expr-lang/expr v1.17.7/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
+github.com/expr-lang/expr v1.17.8 h1:W1loDTT+0PQf5YteHSTpju2qfUfNoBt4yw9+wOEU9VM=
+github.com/expr-lang/expr v1.17.8/go.mod h1:8/vRC7+7HBzESEqt5kKpYXxrxkr31SaO8r40VO/1IT4=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=
 github.com/fatih/color v1.17.0/go.mod h1:YZ7TlrGPkiz6ku9fK3TLD/pl3CpsiFyu8N92HLgmosI=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=

--- a/pkg/scm/github/context.go
+++ b/pkg/scm/github/context.go
@@ -54,23 +54,23 @@ func NewContext(ctx context.Context, _, token string) (*Context, error) {
 	evalContext.PullRequest.Labels = evalContext.PullRequest.ResponseLabels.Nodes
 	evalContext.PullRequest.ResponseLabels = nil
 
-	if len(evalContext.PullRequest.ResponseOldestCommits.Nodes) > 0 {
-		evalContext.PullRequest.FirstCommit = evalContext.PullRequest.ResponseOldestCommits.Nodes[0].Commit
+	if evalContext.PullRequest.ResponseFirstCommits != nil && len(evalContext.PullRequest.ResponseFirstCommits.Nodes) > 0 {
+		evalContext.PullRequest.FirstCommit = evalContext.PullRequest.ResponseFirstCommits.Nodes[0].Commit
 
 		tmp := time.Since(evalContext.PullRequest.FirstCommit.CommittedDate)
 		evalContext.PullRequest.TimeSinceFirstCommit = &tmp
 	}
 
-	evalContext.PullRequest.ResponseOldestCommits = nil
+	evalContext.PullRequest.ResponseFirstCommits = nil
 
-	if len(evalContext.PullRequest.ResponseNewestCommits.Nodes) > 0 {
-		evalContext.PullRequest.LastCommit = evalContext.PullRequest.ResponseNewestCommits.Nodes[0].Commit
+	if evalContext.PullRequest.ResponseLastCommits != nil && len(evalContext.PullRequest.ResponseLastCommits.Nodes) > 0 {
+		evalContext.PullRequest.LastCommit = evalContext.PullRequest.ResponseLastCommits.Nodes[0].Commit
 
 		tmp := time.Since(evalContext.PullRequest.LastCommit.CommittedDate)
 		evalContext.PullRequest.TimeSinceLastCommit = &tmp
 	}
 
-	evalContext.PullRequest.ResponseNewestCommits = nil
+	evalContext.PullRequest.ResponseLastCommits = nil
 
 	if evalContext.PullRequest.FirstCommit != nil && evalContext.PullRequest.LastCommit != nil {
 		tmp := evalContext.PullRequest.FirstCommit.CommittedDate.Sub(evalContext.PullRequest.LastCommit.CommittedDate).Round(time.Hour)

--- a/pkg/scm/github/context.go
+++ b/pkg/scm/github/context.go
@@ -54,23 +54,23 @@ func NewContext(ctx context.Context, _, token string) (*Context, error) {
 	evalContext.PullRequest.Labels = evalContext.PullRequest.ResponseLabels.Nodes
 	evalContext.PullRequest.ResponseLabels = nil
 
-	if evalContext.PullRequest.ResponseFirstCommits != nil && len(evalContext.PullRequest.ResponseFirstCommits.Nodes) > 0 {
-		evalContext.PullRequest.FirstCommit = evalContext.PullRequest.ResponseFirstCommits.Nodes[0].Commit
+	if len(evalContext.PullRequest.ResponseOldestCommits.Nodes) > 0 {
+		evalContext.PullRequest.FirstCommit = evalContext.PullRequest.ResponseOldestCommits.Nodes[0].Commit
 
 		tmp := time.Since(evalContext.PullRequest.FirstCommit.CommittedDate)
 		evalContext.PullRequest.TimeSinceFirstCommit = &tmp
 	}
 
-	evalContext.PullRequest.ResponseFirstCommits = nil
+	evalContext.PullRequest.ResponseOldestCommits = nil
 
-	if evalContext.PullRequest.ResponseLastCommits != nil && len(evalContext.PullRequest.ResponseLastCommits.Nodes) > 0 {
-		evalContext.PullRequest.LastCommit = evalContext.PullRequest.ResponseLastCommits.Nodes[0].Commit
+	if len(evalContext.PullRequest.ResponseNewestCommits.Nodes) > 0 {
+		evalContext.PullRequest.LastCommit = evalContext.PullRequest.ResponseNewestCommits.Nodes[0].Commit
 
 		tmp := time.Since(evalContext.PullRequest.LastCommit.CommittedDate)
 		evalContext.PullRequest.TimeSinceLastCommit = &tmp
 	}
 
-	evalContext.PullRequest.ResponseLastCommits = nil
+	evalContext.PullRequest.ResponseNewestCommits = nil
 
 	if evalContext.PullRequest.FirstCommit != nil && evalContext.PullRequest.LastCommit != nil {
 		tmp := evalContext.PullRequest.FirstCommit.CommittedDate.Sub(evalContext.PullRequest.LastCommit.CommittedDate).Round(time.Hour)

--- a/pkg/scm/gitlab/context.go
+++ b/pkg/scm/gitlab/context.go
@@ -30,9 +30,13 @@ func NewContext(ctx context.Context, baseURL, token string) (*Context, error) {
 		variables   = map[string]any{
 			"project_id": graphql.ID(state.ProjectID(ctx)),
 			"mr_id":      state.MergeRequestID(ctx),
+			// TODO: add support for pipeline events here
+			// pipeline_id: state.PipelineID(ctx),
 		}
 	)
 
+	// TODO: query should be updated to pull `stages`, ids, status, detailed_status, other object attributes, `builds` array and `source_pipeline` into evalContext Pipeline field
+	// TODO: https://docs.gitlab.com/user/project/integrations/webhook_events/#pipeline-events
 	if err := client.Query(ctx, &evalContext, variables); err != nil {
 		return nil, err
 	}

--- a/pkg/scm/gitlab/context.go
+++ b/pkg/scm/gitlab/context.go
@@ -28,9 +28,10 @@ func NewContext(ctx context.Context, baseURL, token string) (*Context, error) {
 	var (
 		evalContext *Context
 		variables   = map[string]any{
-			"project_id":  graphql.ID(state.ProjectID(ctx)),
-			"mr_id":       state.MergeRequestID(ctx),
-			"pipeline_id": graphql.ID(state.PipelineID(ctx)),
+			"project_id":             graphql.ID(state.ProjectID(ctx)),
+			"mr_id":                  state.MergeRequestID(ctx),
+			"pipeline_id":            graphql.ID(state.PipelineID(ctx)),
+			"request_pipeline_by_id": state.PipelineID(ctx) != "",
 		}
 	)
 

--- a/pkg/scm/gitlab/context.go
+++ b/pkg/scm/gitlab/context.go
@@ -75,7 +75,9 @@ func NewContext(ctx context.Context, baseURL, token string) (*Context, error) {
 	} else {
 		evalContext.Pipeline = evalContext.MergeRequest.HeadPipeline
 	}
+
 	evalContext.Project.ResponsePipeline = nil
+
 	if evalContext.Pipeline != nil && evalContext.Pipeline.ResponseJobs != nil {
 		evalContext.Pipeline.Jobs = evalContext.Pipeline.ResponseJobs.Nodes
 		evalContext.Pipeline.ResponseJobs = nil

--- a/pkg/scm/gitlab/context.go
+++ b/pkg/scm/gitlab/context.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"log/slog"
 	"time"
 
 	"github.com/hasura/go-graphql-client"
@@ -12,6 +13,79 @@ import (
 )
 
 var _ scm.EvalContext = (*Context)(nil)
+
+// pipelineByIDResponse is used for a separate low-complexity query to fetch pipeline by ID (pipeline events only).
+// It requests only scalar pipeline fields (no jobs) to stay under GitLab's complexity limit.
+type pipelineByIDResponse struct {
+	Project *struct {
+		Pipeline *minimalPipelineForQuery `graphql:"pipeline(iid: $pipeline_id)"`
+	} `graphql:"project(fullPath: $project_id)"`
+}
+
+type minimalPipelineForQuery struct {
+	Active        bool               `graphql:"active"`
+	Cancelable    bool               `graphql:"cancelable"`
+	Complete      bool               `graphql:"complete"`
+	Duration      *int               `graphql:"duration"`
+	FailureReason *string            `graphql:"failureReason"`
+	FinishedAt    *time.Time         `graphql:"finishedAt"`
+	ID            string             `graphql:"id"`
+	Iid           string             `graphql:"iid"`
+	Latest        bool               `graphql:"latest"`
+	Name          *string            `graphql:"name"`
+	Path          *string            `graphql:"path"`
+	Retryable     bool               `graphql:"retryable"`
+	StartedAt     *time.Time         `graphql:"startedAt"`
+	Status        PipelineStatusEnum `graphql:"status"`
+	Stuck         bool               `graphql:"stuck"`
+	TotalJobs     int                `graphql:"totalJobs"`
+	UpdatedAt     time.Time          `graphql:"updatedAt"`
+	Warnings      bool               `graphql:"warnings"`
+}
+
+func (m *minimalPipelineForQuery) toContextPipeline() *ContextPipeline {
+	if m == nil {
+		return nil
+	}
+	return &ContextPipeline{
+		Active:        m.Active,
+		Cancelable:    m.Cancelable,
+		Complete:      m.Complete,
+		Duration:      m.Duration,
+		FailureReason: m.FailureReason,
+		FinishedAt:    m.FinishedAt,
+		ID:            m.ID,
+		Iid:           m.Iid,
+		Latest:        m.Latest,
+		Name:          m.Name,
+		Path:          m.Path,
+		Retryable:     m.Retryable,
+		StartedAt:     m.StartedAt,
+		Status:        m.Status,
+		Stuck:         m.Stuck,
+		TotalJobs:     m.TotalJobs,
+		UpdatedAt:     m.UpdatedAt,
+		Warnings:      m.Warnings,
+		Jobs:         nil, // not fetched in minimal query to keep complexity low
+	}
+}
+
+// fetchPipelineByID runs a small GraphQL query to load a pipeline by ID. Used only for pipeline webhook events.
+func fetchPipelineByID(ctx context.Context, client *graphql.Client, projectID, pipelineID string) *ContextPipeline {
+	var resp pipelineByIDResponse
+	err := client.Query(ctx, &resp, map[string]any{
+		"project_id":  graphql.ID(projectID),
+		"pipeline_id": graphql.ID(pipelineID),
+	})
+	if err != nil {
+		slogctx.Debug(ctx, "Failed to fetch pipeline by ID (pipeline event)", slog.Any("error", err))
+		return nil
+	}
+	if resp.Project == nil || resp.Project.Pipeline == nil {
+		return nil
+	}
+	return resp.Project.Pipeline.toContextPipeline()
+}
 
 func NewContext(ctx context.Context, baseURL, token string) (*Context, error) {
 	httpClient := oauth2.NewClient(
@@ -28,9 +102,8 @@ func NewContext(ctx context.Context, baseURL, token string) (*Context, error) {
 	var (
 		evalContext *Context
 		variables   = map[string]any{
-			"project_id":  graphql.ID(state.ProjectID(ctx)),
-			"mr_id":       state.MergeRequestID(ctx),
-			"pipeline_id": state.PipelineID(ctx),
+			"project_id": graphql.ID(state.ProjectID(ctx)),
+			"mr_id":      state.MergeRequestID(ctx),
 		}
 	)
 
@@ -68,8 +141,14 @@ func NewContext(ctx context.Context, baseURL, token string) (*Context, error) {
 	evalContext.Group = evalContext.Project.ResponseGroup
 	evalContext.Project.ResponseGroup = nil
 
-	// Set top-level Pipeline from Merge Request's HeadPipeline
+	// Set top-level Pipeline: for pipeline webhook events fetch by ID in a separate low-complexity query;
+	// for merge_request/note events use the MR's HeadPipeline.
 	evalContext.Pipeline = evalContext.MergeRequest.HeadPipeline
+	if pid := state.PipelineID(ctx); pid != "" {
+		if p := fetchPipelineByID(ctx, client, state.ProjectID(ctx), pid); p != nil {
+			evalContext.Pipeline = p
+		}
+	}
 	if evalContext.Pipeline != nil && evalContext.Pipeline.ResponseJobs != nil {
 		evalContext.Pipeline.Jobs = evalContext.Pipeline.ResponseJobs.Nodes
 		evalContext.Pipeline.ResponseJobs = nil

--- a/pkg/scm/gitlab/context_pipeline.go
+++ b/pkg/scm/gitlab/context_pipeline.go
@@ -1,17 +1,20 @@
 package gitlab
 
+import "strings"
+
 const (
 	PipelineStatusFailed = "failed"
 )
 
-// HasFailedJobs returns true if the pipeline has any jobs with status "failed"
+// has_failed_jobs
 func (p *ContextPipeline) HasFailedJobs() bool {
 	if p == nil {
 		return false
 	}
 
 	for _, job := range p.Jobs {
-		if job.Status != nil && *job.Status == PipelineStatusFailed {
+		status := strings.ToLower(*job.Status)
+		if status == PipelineStatusFailed {
 			return true
 		}
 	}

--- a/pkg/scm/gitlab/context_pipeline.go
+++ b/pkg/scm/gitlab/context_pipeline.go
@@ -1,0 +1,20 @@
+package gitlab
+
+const (
+	PipelineStatusFailed = "failed"
+)
+
+// HasFailedJobs returns true if the pipeline has any jobs with status "failed"
+func (p *ContextPipeline) HasFailedJobs() bool {
+	if p == nil {
+		return false
+	}
+
+	for _, job := range p.Jobs {
+		if job.Status != nil && *job.Status == PipelineStatusFailed {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/state/context.go
+++ b/pkg/state/context.go
@@ -19,6 +19,7 @@ const (
 	configFilePath
 	dryRun
 	mergeRequestID
+	pipelineID
 	projectID
 	provider
 	startTime
@@ -145,6 +146,21 @@ func ShouldUpdatePipeline(ctx context.Context) (bool, string) {
 
 func MergeRequestID(ctx context.Context) string {
 	return ctx.Value(mergeRequestID).(string) //nolint:forcetypeassert
+}
+
+func PipelineID(ctx context.Context) string {
+	val := ctx.Value(pipelineID)
+	if val == nil {
+		return ""
+	}
+
+	return val.(string) //nolint:forcetypeassert
+}
+
+func WithPipelineID(ctx context.Context, id string) context.Context {
+	ctx = slogctx.With(ctx, slog.String("pipeline_id", id))
+
+	return context.WithValue(ctx, pipelineID, id)
 }
 
 func MergeRequestIDInt(ctx context.Context) int {

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -576,8 +576,6 @@ type ContextPipeline {
   Status: PipelineStatusEnum!
   "If the pipeline is stuck"
   Stuck: Boolean!
-  "Whether this pipeline ran on a tag"
-  Tag: Boolean!
   "The total number of jobs in the pipeline"
   TotalJobs: Int!
   "Timestamp of the pipeline's last activity"
@@ -608,8 +606,6 @@ type ContextPipelineJob {
   ManualJob: Boolean!
   "Name of the job"
   Name: String
-  "Ref (branch or tag) for the job"
-  Ref: String
   "Indicates that the job is retried"
   Retried: Boolean
   "Schedule for the build"

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -47,6 +47,9 @@ type Context {
   "Information about the event that triggered the evaluation. Empty when not using webhook server."
   WebhookEvent: Any @generated @expr(key: "webhook_event")
 
+  "Information about the Pipeline that triggered the evaluation. Only populated for pipeline webhook events."
+  Pipeline: ContextPipeline @generated
+
   "Internal state for tracing what actions has been executed during evaluation"
   ActionGroups: Map @generated @internal
 }
@@ -249,6 +252,9 @@ type ContextProject {
   MergeRequest: ContextMergeRequest
     @internal
     @graphql(key: "mergeRequest(iid: $mr_id)")
+  ResponsePipeline: ContextPipeline
+    @internal
+    @graphql(key: "pipeline(iid: $pipeline_id)")
   ResponseGroup: ContextGroup @internal @graphql(key: "group")
 }
 
@@ -556,18 +562,74 @@ type ContextPipeline {
   Name: String
   "Relative path to the pipeline's page"
   Path: String
+  "Git ref (branch or tag) that the pipeline ran on"
+  Ref: String
   "Specifies if a pipeline can be retried"
   Retryable: Boolean!
+  "SHA of the commit the pipeline ran on"
+  Sha: String
+  "How the pipeline was triggered (push, web, trigger, schedule, api, external, pipeline, etc.)"
+  Source: String
   "Timestamp when the pipeline was started"
   StartedAt: Time
   "Status of the pipeline"
   Status: PipelineStatusEnum!
   "If the pipeline is stuck"
   Stuck: Boolean!
+  "Whether this pipeline ran on a tag"
+  Tag: Boolean!
   "The total number of jobs in the pipeline"
   TotalJobs: Int!
   "Timestamp of the pipeline's last activity"
   UpdatedAt: Time!
   "Indicates if a pipeline has warnings"
   Warnings: Boolean!
+
+  #
+  # Connections
+  #
+
+  "Jobs in this pipeline"
+  Jobs: [ContextPipelineJob!] @generated
+  ResponseJobs: ContextPipelineJobsNode @internal @graphql(key: "jobs(first: 100)")
 }
+
+# Job in a pipeline
+type ContextPipelineJob {
+  "Whether the job is active"
+  Active: Boolean!
+  "Whether this job is allowed to fail"
+  AllowFailure: Boolean!
+  "Duration of the job in seconds"
+  Duration: Int
+  "ID of the job"
+  ID: String!
+  "Whether the job is a manual action"
+  ManualJob: Boolean!
+  "Name of the job"
+  Name: String
+  "Ref (branch or tag) for the job"
+  Ref: String
+  "Indicates that the job is retried"
+  Retried: Boolean
+  "Schedule for the build"
+  ScheduledAt: Time
+  "Stage of the job"
+  Stage: ContextPipelineStage
+  "Status of the job"
+  Status: String
+  "Indicates the job is stuck"
+  Stuck: Boolean!
+}
+
+# Stage in a pipeline
+type ContextPipelineStage {
+  "Name of the stage"
+  Name: String
+}
+
+# Internal only, used to de-nest connections
+type ContextPipelineJobsNode {
+  Nodes: [ContextPipelineJob!] @internal
+}
+

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -548,12 +548,8 @@ type ContextPipeline {
   Cancelable: Boolean!
   "Indicates if a pipeline is complete"
   Complete: Boolean!
-  "Duration of the pipeline in seconds"
-  Duration: Int
   "The reason why the pipeline failed"
   FailureReason: String
-  "Timestamp of the pipeline's completion"
-  FinishedAt: Time
   "ID of the pipeline"
   ID: String!
   "Internal ID of the pipeline"
@@ -572,16 +568,12 @@ type ContextPipeline {
   Sha: String
   "How the pipeline was triggered (push, web, trigger, schedule, api, external, pipeline, etc.)"
   Source: String
-  "Timestamp when the pipeline was started"
-  StartedAt: Time
   "Status of the pipeline"
   Status: PipelineStatusEnum!
   "If the pipeline is stuck"
   Stuck: Boolean!
   "The total number of jobs in the pipeline"
   TotalJobs: Int!
-  "Timestamp of the pipeline's last activity"
-  UpdatedAt: Time!
   "Indicates if a pipeline has warnings"
   Warnings: Boolean!
 
@@ -600,8 +592,6 @@ type ContextPipelineJob {
   Active: Boolean!
   "Whether this job is allowed to fail"
   AllowFailure: Boolean!
-  "Duration of the job in seconds"
-  Duration: Int
   "ID of the job"
   ID: String!
   "Whether the job is a manual action"
@@ -610,8 +600,6 @@ type ContextPipelineJob {
   Name: String
   "Indicates that the job is retried"
   Retried: Boolean
-  "Schedule for the build"
-  ScheduledAt: Time
   "Stage of the job"
   Stage: ContextPipelineStage
   "Status of the job"

--- a/schema/gitlab.schema.graphqls
+++ b/schema/gitlab.schema.graphqls
@@ -254,7 +254,7 @@ type ContextProject {
     @graphql(key: "mergeRequest(iid: $mr_id)")
   ResponsePipeline: ContextPipeline
     @internal
-    @graphql(key: "pipeline(iid: $pipeline_id)")
+    @graphql(key: "pipeline(iid: $pipeline_id) @include(if: $request_pipeline_by_id)")
   ResponseGroup: ContextGroup @internal @graphql(key: "group")
 }
 
@@ -379,6 +379,8 @@ type ContextMergeRequest {
   Labels: [ContextLabel!] @generated
   "Pipeline running on the branch HEAD of the merge request"
   HeadPipeline: ContextPipeline
+    @internal
+    @graphql(key: "headPipeline @skip(if: $request_pipeline_by_id)")
 
   #
   # scm-engine customs


### PR DESCRIPTION
## Changes
- Adds support for processing pipeline events from Gitlab webhook, allowing the pipeline fields to be accessible from the scm-engine config
- Includes an additional helper method for checking if any job has failed `pipeline.has_failed_jobs()`
- Added example to documentation
- Fixes the security vulnerability in `expr` by upgrading and in other libraries by setting to toolchain to `1.24.13`
- Added `pipeline_id` as a variable to the graphql query, which increased complexity to over 308 (max: 250)
  - Added a skip/include annotation to reduce to 257
  - Removed any timestamp related tags from the pipeline + pipeline jobs to get it just under 250, since there is no good use case at the moment for timestamp based evaluation.