### PR TITLE
New assign reviewer behavior for random mode + add new static mode

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -159,9 +159,16 @@ This key controls what kind of action that should be taken.
 
 * `#!yaml assign_reviewers` to assign reviewers to the Merge Request
 
-      Reviewers are only assigned when the Merge Request has no reviewers yet, so
-      re-running `scm-engine` will not keep adding people. The Merge Request author
-      is never assigned as their own reviewer.
+      By default (`mode: random`), reviewers are "topped up" from the `source`:
+      reviewers from the source who are already assigned count towards `limit`, and
+      only enough new ones are added to reach it. Re-running `scm-engine` therefore
+      does not keep adding people — it stops once `limit` is satisfied or there are
+      no new reviewers left to add. Use `mode: static` to always ensure a specific,
+      explicitly listed set of reviewers is assigned, even when the Merge Request
+      already has reviewers. For the `codeowners` and `backstage` sources, the Merge
+      Request author is not assigned as their own reviewer. See
+      [Reviewer assignment modes](gitlab/examples.md#reviewer-assignment-modes) for
+      details and examples.
 
       *Additional fields:*
 
@@ -172,8 +179,8 @@ This key controls what kind of action that should be taken.
           * `#!yaml static` use the user IDs listed in `user_ids`.
 
       - (optional) `#!css user_ids` A list of user IDs to pick from. Required when `source` is `static`, ignored otherwise.
-      - (optional) `#!css limit` The maximum number of reviewers to assign. Defaults to `1`.
-      - (optional) `#!css mode` How reviewers are picked from the eligible set. Only `random` is supported, which is also the default.
+      - (optional) `#!css limit` The maximum number of reviewers to assign. Defaults to `1`. Ignored when `mode` is `static`.
+      - (optional) `#!css mode` How reviewers are picked from the eligible set. One of `random` (default) or `static`. `random` picks reviewers at random from the `source`, topping up until `limit` reviewers from the source are assigned. `static` assigns all listed `user_ids` (ignoring `limit`) and always ensures they are present, even alongside existing reviewers; it is only valid with `source: static`. See [Reviewer assignment modes](gitlab/examples.md#reviewer-assignment-modes).
 
       ```{.yaml title="'assign_reviewers' example"}
       - action: assign_reviewers

--- a/docs/gitlab/examples.md
+++ b/docs/gitlab/examples.md
@@ -255,3 +255,45 @@ actions:
         limit: 2
         mode: random
 ```
+
+## Reviewer assignment modes
+
+The `mode` field controls how reviewers are selected from the `source`.
+
+### `mode: random` (default)
+
+`random` picks reviewers at random from the source, "topping up" the Merge Request until `limit` reviewers **from the source** are assigned:
+
+- It counts how many of the source's reviewers are already assigned towards the `limit`.
+- If the `limit` is already satisfied by reviewers from the source, it does nothing.
+- Otherwise it randomly assigns just enough not-yet-assigned reviewers from the source to reach the `limit`.
+- Existing reviewers are always preserved, and reviewers are never added twice, so repeated evaluations are idempotent.
+
+Reviewers that are not part of the source (for example, someone added manually) do not count towards the `limit`.
+
+### `mode: static`
+
+The `random` mode only ever assigns reviewers that come from the source. When you need specific, explicitly listed reviewers to **always** be assigned — even alongside unrelated reviewers, and regardless of `limit` — use `mode: static`:
+
+```yaml
+# yaml-language-server: $schema=https://jippi.github.io/scm-engine/scm-engine.schema.json
+
+actions:
+  - name: "assign"
+    if: |1
+        --8<-- "docs/gitlab/snippets/assign-merge-request/assign-if.expr"
+    then:
+      - action: assign_reviewers
+        source: static
+        user_ids:
+          - "123"
+        mode: static
+```
+
+`mode: static` behaves as follows:
+
+- It assigns **all** listed `user_ids`. The `limit` field is ignored in this mode.
+- It **always** ensures those users are assigned, even when other reviewers are already present.
+- Existing reviewers are **preserved** — the listed users are added alongside them, never replacing them.
+- It is **idempotent**: if a listed user is already a reviewer, they are not re-added and the Merge Request is left untouched.
+- It is only supported with `source: static`. Using it with `codeowners` or `backstage` is a configuration error.

--- a/pkg/config/action_step.go
+++ b/pkg/config/action_step.go
@@ -94,8 +94,16 @@ type AssignReviewers struct {
 	UserIDs []string `json:"user_ids,omitempty" yaml:"user_ids,omitempty"`
 	// The max number of reviewers to assign
 	Limit int `json:"limit,omitempty" yaml:"limit,omitempty"`
-	// The mode of assigning reviewers
-	Mode string `json:"mode,omitempty" yaml:"mode,omitempty" jsonschema:"enum=random"`
+	// The mode of assigning reviewers.
+	//
+	// "random" (default) randomly assigns reviewers from the source, topping up until
+	// `limit` reviewers from the source are assigned. Reviewers from the source that are
+	// already assigned count towards the `limit`, and existing reviewers are preserved.
+	//
+	// "static" assigns all explicitly listed `user_ids` (`limit` is ignored), always
+	// ensuring they are present even when other reviewers are already assigned. Only
+	// supported with `source: static`.
+	Mode string `json:"mode,omitempty" yaml:"mode,omitempty" jsonschema:"enum=random,enum=static"`
 }
 
 type AddLabelAction struct {

--- a/pkg/scm/gitlab/client_actioner_assign.go
+++ b/pkg/scm/gitlab/client_actioner_assign.go
@@ -106,17 +106,28 @@ func (c *Client) AssignReviewers(ctx context.Context, evalContext scm.EvalContex
 		// entirely when reviewers already exist or endlessly adding on repeat runs.
 		var candidates scm.Actors
 
-		satisfied := 0
+		satisfiedIDs := make(map[int]struct{})
+		candidateIDs := make(map[int]struct{})
 
 		for _, actor := range eligibleReviewers {
-			if _, ok := alreadyAssigned[actor.IntID()]; ok {
-				satisfied++
-
+			id := actor.IntID()
+			if id == 0 {
 				continue
 			}
 
+			if _, ok := alreadyAssigned[id]; ok {
+				satisfiedIDs[id] = struct{}{}
+				continue
+			}
+
+			if _, ok := candidateIDs[id]; ok {
+				continue
+			}
+			candidateIDs[id] = struct{}{}
 			candidates = append(candidates, actor)
 		}
+
+		satisfied := len(satisfiedIDs)
 
 		needed := desiredLimit - satisfied
 		if needed > len(candidates) {

--- a/pkg/scm/gitlab/client_actioner_assign.go
+++ b/pkg/scm/gitlab/client_actioner_assign.go
@@ -2,6 +2,7 @@ package gitlab
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"strconv"
 
@@ -21,17 +22,27 @@ func (c *Client) AssignReviewers(ctx context.Context, evalContext scm.EvalContex
 		return err
 	}
 
-	mode, err := step.OptionalStringEnum("mode", "random", "random")
+	mode, err := step.OptionalStringEnum("mode", "random", "random", "static")
 	if err != nil {
 		return err
 	}
 
-	// prevents misuse and situations where evaluate will assign reviewers endlessly
-	existingReviewers := evalContext.GetReviewers()
-	if len(existingReviewers) > 0 {
-		slogctx.Debug(ctx, "Reviewers already assigned", slog.Any("reviewers", existingReviewers))
+	// "static" mode assigns an explicitly listed set of reviewers, so it is only
+	// meaningful together with an explicit "static" user list.
+	if mode == "static" && source != "static" {
+		return errors.New("step field 'mode: static' is only supported with 'source: static'")
+	}
 
-		return nil
+	existingReviewers := evalContext.GetReviewers()
+
+	// Look up which reviewers are already assigned. Both modes use this to avoid
+	// re-adding people and to preserve the existing reviewers when updating, since
+	// GitLab's "reviewer_ids" replaces the whole set on update.
+	alreadyAssigned := make(map[int]struct{}, len(existingReviewers))
+	for _, reviewer := range existingReviewers {
+		if id := reviewer.IntID(); id != 0 {
+			alreadyAssigned[id] = struct{}{}
+		}
 	}
 
 	var eligibleReviewers []scm.Actor
@@ -87,26 +98,74 @@ func (c *Client) AssignReviewers(ctx context.Context, evalContext scm.EvalContex
 
 	var reviewers scm.Actors
 
-	limit := desiredLimit
-	if limit > len(eligibleReviewers) {
-		limit = len(eligibleReviewers)
-	}
-
 	switch mode {
 	case "random":
-		reviewers = make(scm.Actors, limit)
+		// Only the eligible reviewers that are not already assigned are candidates for
+		// selection, and the ones already assigned count towards the limit. This "tops
+		// up" reviewers from the list until the limit is satisfied, rather than skipping
+		// entirely when reviewers already exist or endlessly adding on repeat runs.
+		var candidates scm.Actors
+
+		satisfied := 0
+
+		for _, actor := range eligibleReviewers {
+			if _, ok := alreadyAssigned[actor.IntID()]; ok {
+				satisfied++
+
+				continue
+			}
+
+			candidates = append(candidates, actor)
+		}
+
+		needed := desiredLimit - satisfied
+		if needed > len(candidates) {
+			needed = len(candidates)
+		}
+
+		if needed < 0 {
+			needed = 0
+		}
+
+		reviewers = make(scm.Actors, needed)
 
 		rand := state.RandomSeed(ctx)
-		perm := rand.Perm(len(eligibleReviewers))
+		perm := rand.Perm(len(candidates))
 
-		for i := 0; i < limit; i++ {
-			reviewers[i] = eligibleReviewers[perm[i]]
+		for i := 0; i < needed; i++ {
+			reviewers[i] = candidates[perm[i]]
 		}
+
+		break
+	case "static":
+		// Assign every explicitly listed reviewer; "limit" is ignored in this mode.
+		reviewers = append(scm.Actors{}, eligibleReviewers...)
 
 		break
 	}
 
-	reviewerIDs := make([]int, 0, len(reviewers))
+	// Build the final reviewer set. GitLab's "reviewer_ids" replaces the whole set on
+	// update, so any existing reviewers must be preserved to avoid removing them. Newly
+	// selected reviewers are de-duplicated against the reviewers already present.
+	reviewerIDs := make([]int, 0, len(existingReviewers)+len(reviewers))
+	seen := make(map[int]struct{}, cap(reviewerIDs))
+
+	// Preserve the reviewers already assigned; selected reviewers are added alongside them.
+	for _, reviewer := range existingReviewers {
+		id := reviewer.IntID()
+		if id == 0 {
+			continue
+		}
+
+		if _, ok := seen[id]; ok {
+			continue
+		}
+
+		seen[id] = struct{}{}
+		reviewerIDs = append(reviewerIDs, id)
+	}
+
+	added := 0
 
 	for _, reviewer := range reviewers {
 		id := reviewer.IntID()
@@ -118,11 +177,25 @@ func (c *Client) AssignReviewers(ctx context.Context, evalContext scm.EvalContex
 			continue
 		}
 
+		if _, ok := seen[id]; ok {
+			continue
+		}
+
+		seen[id] = struct{}{}
 		reviewerIDs = append(reviewerIDs, id)
+		added++
+	}
+
+	// If there are no new reviewers to add, skip the update to avoid needless MR churn.
+	// This makes both modes idempotent across repeated evaluations.
+	if added == 0 {
+		slogctx.Debug(ctx, "No new reviewers to assign")
+
+		return nil
 	}
 
 	if state.IsDryRun(ctx) {
-		slogctx.Info(ctx, "(Dry Run) Assigning MR", slog.String("source", source), slog.Int("limit", limit), slog.String("mode", mode), slog.Any("reviewers", reviewers))
+		slogctx.Info(ctx, "(Dry Run) Assigning MR", slog.String("source", source), slog.Int("limit", desiredLimit), slog.String("mode", mode), slog.Any("reviewers", reviewers))
 
 		return nil
 	}

--- a/pkg/scm/gitlab/client_actioner_assign.go
+++ b/pkg/scm/gitlab/client_actioner_assign.go
@@ -117,13 +117,16 @@ func (c *Client) AssignReviewers(ctx context.Context, evalContext scm.EvalContex
 
 			if _, ok := alreadyAssigned[id]; ok {
 				satisfiedIDs[id] = struct{}{}
+
 				continue
 			}
 
 			if _, ok := candidateIDs[id]; ok {
 				continue
 			}
+
 			candidateIDs[id] = struct{}{}
+
 			candidates = append(candidates, actor)
 		}
 

--- a/pkg/scm/gitlab/client_actioner_assign_test.go
+++ b/pkg/scm/gitlab/client_actioner_assign_test.go
@@ -261,10 +261,11 @@ func TestAssignReviewers_static(t *testing.T) {
 			wantErr:                  errors.New("Required 'step' key 'user_ids' is missing"),
 		},
 		{
-			name: "should not assign if reviewers already exist",
+			name: "should not assign if list members already satisfy the limit",
 			step: config.ActionStep{
 				"source":   "static",
-				"user_ids": []string{"100", "200"},
+				"user_ids": []string{"50", "100"},
+				"limit":    1,
 			},
 			mockGetReviewersResponse: scm.Actors{
 				{ID: "50", Username: "existing"},
@@ -309,6 +310,199 @@ func TestAssignReviewers_static(t *testing.T) {
 				assert.Len(t, *update.ReviewerIDs, wantLimit)
 				assert.Equal(t, tt.wantUpdate.ReviewerIDs, update.ReviewerIDs)
 			}
+		})
+	}
+}
+
+func TestAssignReviewers_staticMode(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                     string
+		step                     config.ActionStep
+		mockGetReviewersResponse scm.Actors
+		wantReviewerIDs          *[]int
+		wantErr                  error
+	}{
+		{
+			name: "should assign listed user when no reviewers exist",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"100"},
+				"mode":     "static",
+			},
+			mockGetReviewersResponse: nil,
+			wantReviewerIDs:          scm.Ptr([]int{100}),
+			wantErr:                  nil,
+		},
+		{
+			name: "should assign listed user and preserve existing reviewers",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"100"},
+				"mode":     "static",
+			},
+			mockGetReviewersResponse: scm.Actors{
+				{ID: "50", Username: "existing"},
+			},
+			wantReviewerIDs: scm.Ptr([]int{50, 100}),
+			wantErr:         nil,
+		},
+		{
+			name: "should be a no-op when listed user is already a reviewer",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"50"},
+				"mode":     "static",
+			},
+			mockGetReviewersResponse: scm.Actors{
+				{ID: "50", Username: "existing"},
+			},
+			wantReviewerIDs: nil,
+			wantErr:         nil,
+		},
+		{
+			name: "should dedup listed users against existing reviewers",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"50", "100"},
+				"mode":     "static",
+			},
+			mockGetReviewersResponse: scm.Actors{
+				{ID: "50", Username: "existing"},
+			},
+			wantReviewerIDs: scm.Ptr([]int{50, 100}),
+			wantErr:         nil,
+		},
+		{
+			name: "should assign all listed users, ignoring limit",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"100", "200", "300"},
+				"mode":     "static",
+				"limit":    2,
+			},
+			mockGetReviewersResponse: nil,
+			wantReviewerIDs:          scm.Ptr([]int{100, 200, 300}),
+			wantErr:                  nil,
+		},
+		{
+			name: "should error when static mode is used with a non-static source",
+			step: config.ActionStep{
+				"source": "codeowners",
+				"mode":   "static",
+			},
+			mockGetReviewersResponse: nil,
+			wantReviewerIDs:          nil,
+			wantErr:                  errors.New("step field 'mode: static' is only supported with 'source: static'"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			evalContext := new(evalContextMock)
+			evalContext.On("GetReviewers").Return(tt.mockGetReviewersResponse)
+
+			client := &gitlab.Client{}
+			update := &scm.UpdateMergeRequestOptions{}
+
+			ctx := state.WithDryRun(t.Context(), false)
+			ctx = state.WithRandomSeed(ctx, 1)
+
+			err := client.AssignReviewers(ctx, evalContext, update, tt.step)
+
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.wantReviewerIDs, update.ReviewerIDs)
+		})
+	}
+}
+
+func TestAssignReviewers_randomTopUp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                     string
+		step                     config.ActionStep
+		mockGetReviewersResponse scm.Actors
+		wantReviewerIDs          *[]int
+		wantErr                  error
+	}{
+		{
+			name: "should top up from the list when an existing reviewer is not in the list",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"100"},
+				"mode":     "random",
+			},
+			mockGetReviewersResponse: scm.Actors{
+				{ID: "50", Username: "not-in-list"},
+			},
+			wantReviewerIDs: scm.Ptr([]int{50, 100}),
+			wantErr:         nil,
+		},
+		{
+			name: "should count existing list members towards the limit and top up the remainder",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"100", "200"},
+				"mode":     "random",
+				"limit":    2,
+			},
+			mockGetReviewersResponse: scm.Actors{
+				{ID: "100", Username: "already-assigned"},
+			},
+			wantReviewerIDs: scm.Ptr([]int{100, 200}),
+			wantErr:         nil,
+		},
+		{
+			name: "should do nothing when list members already satisfy the limit",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"100", "200"},
+				"mode":     "random",
+				"limit":    1,
+			},
+			mockGetReviewersResponse: scm.Actors{
+				{ID: "100", Username: "already-assigned"},
+			},
+			wantReviewerIDs: nil,
+			wantErr:         nil,
+		},
+		{
+			name: "should do nothing when all list members are already assigned",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"100"},
+				"mode":     "random",
+				"limit":    5,
+			},
+			mockGetReviewersResponse: scm.Actors{
+				{ID: "100", Username: "already-assigned"},
+			},
+			wantReviewerIDs: nil,
+			wantErr:         nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			evalContext := new(evalContextMock)
+			evalContext.On("GetReviewers").Return(tt.mockGetReviewersResponse)
+
+			client := &gitlab.Client{}
+			update := &scm.UpdateMergeRequestOptions{}
+
+			ctx := state.WithDryRun(t.Context(), false)
+			ctx = state.WithRandomSeed(ctx, 1)
+
+			err := client.AssignReviewers(ctx, evalContext, update, tt.step)
+
+			assert.Equal(t, tt.wantErr, err)
+			assert.Equal(t, tt.wantReviewerIDs, update.ReviewerIDs)
 		})
 	}
 }

--- a/pkg/scm/gitlab/client_actioner_assign_test.go
+++ b/pkg/scm/gitlab/client_actioner_assign_test.go
@@ -261,19 +261,6 @@ func TestAssignReviewers_static(t *testing.T) {
 			wantErr:                  errors.New("Required 'step' key 'user_ids' is missing"),
 		},
 		{
-			name: "should not assign if list members already satisfy the limit",
-			step: config.ActionStep{
-				"source":   "static",
-				"user_ids": []string{"50", "100"},
-				"limit":    1,
-			},
-			mockGetReviewersResponse: scm.Actors{
-				{ID: "50", Username: "existing"},
-			},
-			wantUpdate: &scm.UpdateMergeRequestOptions{},
-			wantErr:    nil,
-		},
-		{
 			name: "should assign single user with default limit",
 			step: config.ActionStep{
 				"source":   "static",
@@ -482,6 +469,23 @@ func TestAssignReviewers_randomTopUp(t *testing.T) {
 				{ID: "100", Username: "already-assigned"},
 			},
 			wantReviewerIDs: nil,
+			wantErr:         nil,
+		},
+		{
+			// needed (2) < len(candidates) (5), so the seeded perm actually chooses a
+			// subset AND its ordering, exercising the candidates[perm[i]] selection path
+			// rather than a fully-determined result.
+			name: "should randomly pick the seeded subset of list members to fill remaining slots",
+			step: config.ActionStep{
+				"source":   "static",
+				"user_ids": []string{"100", "200", "300", "400", "500"},
+				"mode":     "random",
+				"limit":    2,
+			},
+			mockGetReviewersResponse: scm.Actors{
+				{ID: "50", Username: "not-in-list"},
+			},
+			wantReviewerIDs: scm.Ptr([]int{50, 100, 500}), // seeded pick: a "take first N" bug would give {50, 100, 200}
 			wantErr:         nil,
 		},
 	}


### PR DESCRIPTION
Random mode should top-up if the limit isn't satisfied, meaning it should look to see who is already assigned from the reviewer list and only assign from the remaining eligible reviewers when the limit isn't satisified.

Additionally, add a new mode of static which assigns everyone from the eligible reviewers (e.g. when source: static and we provide a hardcoded list of users).


In MR but unrelated to changes: changes in go mod + sum related to fixing govuln checks